### PR TITLE
feat: Add setQuery to NextApiRequestBuilder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
 dist/
 node_modules/
+packages/*/coverage
+packages/*/dist

--- a/README.md
+++ b/README.md
@@ -127,3 +127,30 @@ it('Mock Request and Response with headers', async () => {
   })
 })
 ```
+
+### Mocking Request with route parameters
+
+If your handler depends on some parameters found in the path, eg. it's defined
+in `pages/api/[foo]/echo`, then you can specify it with `setQuery()`.
+
+```ts
+import EchoHandler from './pages/api/[foo]/echo'
+import { NextApiRequestBuilder, ResponseMock } from '@next-testing/api'
+
+it('Mock Request and Response with route parameters', async () => {
+  const req = new NextApiRequestBuilder()
+          .setMethod('GET')
+          .setQuery({
+            foo: 'hello'
+          })
+          .build()
+  const res = ResponseMock()
+
+  EchoHandler(req, res)
+
+  expect(res.getStatusCode()).toEqual(200)
+  expect(res.getBodyJson()).toStrictEqual({
+      foo: 'hello',
+  })
+})
+```

--- a/packages/api/src/request/NextApiRequestBuilder.ts
+++ b/packages/api/src/request/NextApiRequestBuilder.ts
@@ -40,6 +40,11 @@ export class NextApiRequestBuilder {
         return this
     }
 
+    setQuery(query: Record<string, string | string[]>): NextApiRequestBuilder {
+        this.req.query = query
+        return this
+    }
+
     build(): NextApiRequest {
         return this.req
     }

--- a/packages/api/tests/fixture/EchoEndpoint.ts
+++ b/packages/api/tests/fixture/EchoEndpoint.ts
@@ -1,0 +1,9 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+const EchoEndpoint = (req: NextApiRequest, res: NextApiResponse) => {
+    const param = req.query.foo as string
+    const url = req.url
+    res.status(200).json({ foo: param, url })
+}
+
+export default EchoEndpoint

--- a/packages/api/tests/response.test.ts
+++ b/packages/api/tests/response.test.ts
@@ -4,11 +4,12 @@ import {
     NextApiResponseMock,
     ResponseMock,
 } from '../src'
+import { NextApiRequest } from 'next'
 import JSONEndpoint from './fixture/JSONEndpoint'
 import ForwardEndpoint from './fixture/ForwardEndpoint'
-import { NextApiRequest } from 'next'
 import BufferedEndpoint from './fixture/BufferedEndpoint'
 import RedirectEndpoint from './fixture/RedirectEndpoint'
+import EchoEndpoint from './fixture/EchoEndpoint'
 
 describe('testing response', () => {
     it('should be able to parse simple JSON', () => {
@@ -155,6 +156,27 @@ describe('testing response', () => {
                     })
                 )
             )
+        })
+    })
+
+    describe('echo endpoint', () => {
+        it('should read parameters in the request query and url', () => {
+            const req = new NextApiRequestBuilder()
+                .setMethod('GET')
+                .setQuery({
+                    foo: 'hello',
+                })
+                .setUrl('http://localhost/api/hello/echo')
+                .build()
+            const res = ResponseMock()
+
+            EchoEndpoint(req, res)
+
+            expect(res.getStatusCode()).toEqual(200)
+            expect(res.getBodyJson()).toStrictEqual({
+                foo: 'hello',
+                url: 'http://localhost/api/hello/echo',
+            })
         })
     })
 


### PR DESCRIPTION
This PR fixes #64 by adding `setQuery` to the request builder class.